### PR TITLE
chore: raise Python baseline to 3.13 and CI matrix to 3.14 (ch-w8v)

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.11, 3.12]
+        python-version: [3.13, 3.14]
 
     steps:
       - uses: actions/checkout@v2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### BREAKING CHANGE
+- Raise minimum supported Python version to 3.13.
+
+### Chore
+- Validate runtime/tooling compatibility on Python 3.14.
+
 ## v6.0.0 (2025-10-07)
 
 ### Feat

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Chartreuse leverages [Helm Hooks](https://helm.sh/docs/topics/charts_hooks/), th
 
 ### Requirements
 
-- Python >= 3.7
+- Python >= 3.13
 - Using Helm to deploy you application
 - This Python package requires the `expecteddeploymentscales.wiremind.io` Kubernetes `Custom Resource Definition`:
 

--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.12
+FROM python:3.13
 
 WORKDIR /app
 

--- a/example/Dockerfile-dev
+++ b/example/Dockerfile-dev
@@ -1,6 +1,6 @@
 # Only used for e2e tests. Do not use in production.
 # For Wiremind use only since it uses our private package wiremind-python
-FROM python:3.12
+FROM python:3.13
 
 WORKDIR /app
 

--- a/example/Dockerfile-dev-auth
+++ b/example/Dockerfile-dev-auth
@@ -1,7 +1,7 @@
 # Only used for e2e tests. Do not use in production.
 # For Wiremind use only since it uses our private package wiremind-python
 
-FROM python:3.12
+FROM python:3.13
 
 WORKDIR /app
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,12 @@ authors = [{ name = "wiremind", email = "dev@wiremind.io" }]
 license="LGPL-3.0-or-later"
 urls = { github = "https://github.com/wiremind/chartreuse"}
 scripts = {chartreuse-upgrade = "chartreuse.chartreuse_upgrade:main"}
-requires-python = ">=3.11.0"
+requires-python = ">=3.13.0"
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+]
 
 dependencies = [
   "alembic",
@@ -50,7 +55,7 @@ dev = [
 
 [tool.ruff]
 line-length = 120
-target-version = "py311"
+target-version = "py313"
 
 [tool.ruff.lint]
 select = [


### PR DESCRIPTION
Tracks `ch-w8v`.

Changes include:
- raise minimum supported Python version to 3.13
- update CI test matrix to include Python 3.13 and 3.14
- align example Docker images/docs with the new runtime baseline

This PR must stay open until required checks are green.