### PR TITLE
feat: drop HELM_IS_INSTALL env-var dependency

### DIFF
--- a/docs/multi-database.md
+++ b/docs/multi-database.md
@@ -67,7 +67,6 @@ For multi-database mode:
 - `CHARTREUSE_ENABLE_STOP_PODS`: Whether to stop pods during migration (optional, default: true)
 - `CHARTREUSE_RELEASE_NAME`: Kubernetes release name
 - `CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT`: Whether to upgrade before deployment (optional, default: false)
-- `HELM_IS_INSTALL`: Whether this is a Helm install operation (optional, default: false)
 
 ## Usage
 

--- a/src/chartreuse/chartreuse_upgrade.py
+++ b/src/chartreuse/chartreuse_upgrade.py
@@ -85,7 +85,9 @@ def main() -> None:
         "false",
         "0",
     )
-    HELM_IS_INSTALL: bool = os.environ.get("HELM_IS_INSTALL", "false").lower() not in ("", "false", "0")
+    # HELM_IS_INSTALL removed: under ArgoCD the env var is always empty, and under
+    # pure Helm flow with upgradeBeforeDeployment=true the existing pattern was to
+    # let the orchestrator restart pods after the hook. Always honour that.
 
     deployment_manager = KubernetesDeploymentManager(release_name=RELEASE_NAME, use_kubeconfig=None)
     chartreuse = Chartreuse(
@@ -102,7 +104,7 @@ def main() -> None:
 
         if not ENABLE_STOP_PODS:
             return
-        if UPGRADE_BEFORE_DEPLOYMENT and not HELM_IS_INSTALL:
+        if UPGRADE_BEFORE_DEPLOYMENT:
             return
 
         try:

--- a/src/chartreuse/tests/conftest.py
+++ b/src/chartreuse/tests/conftest.py
@@ -13,7 +13,6 @@ def configure_os_environ_mock(mocker: MockerFixture, additional_environment: dic
         "CHARTREUSE_RELEASE_NAME": "foo",
         "RUN_TEST_IN_KIND": os.environ.get("RUN_TEST_IN_KIND", ""),
         "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "",
-        "HELM_IS_INSTALL": "",
         "CHARTREUSE_MULTI_CONFIG_PATH": "/mock/config.yaml",
         # Add Kubernetes environment variables to prevent config loading
         "KUBERNETES_SERVICE_HOST": "localhost",

--- a/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade_extended.py
+++ b/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade_extended.py
@@ -116,7 +116,6 @@ class TestMainMultiDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "true",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
         )
 
@@ -166,7 +165,6 @@ class TestMainMultiDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "true",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
         )
 
@@ -234,7 +232,6 @@ class TestMainMultiDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "false",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
         )
 
@@ -246,7 +243,7 @@ class TestMainMultiDatabase:
         mock_k8s_instance.start_pods.assert_not_called()
 
     def test_main_multi_database_upgrade_before_deployment(self, mocker: MockerFixture) -> None:
-        """Test main function with UPGRADE_BEFORE_DEPLOYMENT and not HELM_IS_INSTALL."""
+        """Test main function with UPGRADE_BEFORE_DEPLOYMENT enabled: start_pods should be skipped."""
         mocker.patch("chartreuse.chartreuse_upgrade.ensure_safe_run")
 
         # Mock file existence for config validation
@@ -282,7 +279,6 @@ class TestMainMultiDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "true",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "true",
-                "HELM_IS_INSTALL": "false",
             },
         )
 
@@ -334,7 +330,6 @@ class TestMainMultiDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "true",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
         )
 
@@ -390,7 +385,6 @@ class TestMainSingleDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "true",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
             clear=True,
         )
@@ -450,7 +444,6 @@ class TestMainSingleDatabase:
                 "CHARTREUSE_ENABLE_STOP_PODS": "false",
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
             clear=True,
         )
@@ -523,7 +516,6 @@ class TestMainBooleanParsing:
                 "CHARTREUSE_ENABLE_STOP_PODS": bool_str,  # Test this boolean parsing
                 "CHARTREUSE_RELEASE_NAME": "test-release",
                 "CHARTREUSE_UPGRADE_BEFORE_DEPLOYMENT": "false",
-                "HELM_IS_INSTALL": "false",
             },
             clear=True,
         )


### PR DESCRIPTION
## Summary
- Removes the `HELM_IS_INSTALL` env-var read in `src/chartreuse/chartreuse_upgrade.py:88,105`.
- Simplifies `if UPGRADE_BEFORE_DEPLOYMENT and not HELM_IS_INSTALL: return` → `if UPGRADE_BEFORE_DEPLOYMENT: return` — always behave as upgrade.
- Drops the env var from 8 test fixtures + docs.

## Why
The env var was a Helm-specific install-vs-upgrade signal that doesn't exist under ArgoCD (`helm template` always reports `IsInstall=true`). The branch it gated — "in upgrade-before-deployment mode + first install + we ran migrations + ENABLE_STOP_PODS, then start pods manually" — has an unreachable subcase under ArgoCD, and the orchestrator (ArgoCD or Helm) handles pod rollout via Deployment manifests in all other paths. So always returning without `start_pods()` when `UPGRADE_BEFORE_DEPLOYMENT=true` is the correct behavior under both Helm and ArgoCD flows.

## Test plan
- [x] `uv run pytest` → 88 passed (same as baseline).
- [x] `uv run ruff check` + `ruff format --check` → clean.
- [x] `grep -r HELM_IS_INSTALL src/ docs/` → only the deliberate explanatory comment remains.
- [ ] Reviewer to confirm no internal consumer relies on the env var.

## Coordinated with
- Chartreuse Helm chart 6.3.0: https://github.com/wiremind/wiremind-helm-charts/pull/859 — emits `HELM_IS_INSTALL: \"\"` always under ArgoCD mode, so this drop can land independently of that PR's merge order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)