### PR TITLE
fix(chartreuse): rename HELM_CHART_VERSION env var to HELM_CHART_APP_…

### DIFF
--- a/src/chartreuse/chartreuse_upgrade.py
+++ b/src/chartreuse/chartreuse_upgrade.py
@@ -20,10 +20,10 @@ def ensure_safe_run() -> None:
     # Get "1.2" from "1.2.3"
     package_v_major_minor: list[str] = package_v.split(".", 2)[:2]
 
-    helm_chart_v: str = os.getenv("HELM_CHART_VERSION", "")
+    helm_chart_v: str = os.getenv("HELM_CHART_APP_VERSION", "")
     if not helm_chart_v:
         raise ValueError(
-            "Couldn't get the Chartreuse's Helm Chart version from the env var HELM_CHART_VERSION,"
+            "Couldn't get the Chartreuse's Helm Chart appVersion from the env var HELM_CHART_APP_VERSION,"
             " couldn't make sure that the package is of a compatible version, ABORTING!"
         )
     helm_chart_v_major_minor: list[str] = helm_chart_v.split(".", 2)[:2]

--- a/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade.py
+++ b/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade.py
@@ -17,7 +17,7 @@ def test_chartreuse_upgrade_detected_migration_enabled_stop_pods(
     mocked_stop_pods = mocker.patch("wiremind_kubernetes.KubernetesDeploymentManager.stop_pods")
     mocker.patch("wiremind_kubernetes.KubernetesDeploymentManager.start_pods")
     mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.0.0")
-    configure_os_environ_mock(mocker=mocker, additional_environment={"HELM_CHART_VERSION": "5.0.0"})
+    configure_os_environ_mock(mocker=mocker, additional_environment={"HELM_CHART_APP_VERSION": "5.0.0"})
 
     chartreuse.chartreuse_upgrade.main()
     mocked_stop_pods.assert_called()
@@ -35,7 +35,7 @@ def test_chartreuse_upgrade_detected_migration_disabled_stop_pods(
     mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.0.0")
     configure_os_environ_mock(
         mocker=mocker,
-        additional_environment={"CHARTREUSE_ENABLE_STOP_PODS": "", "HELM_CHART_VERSION": "5.0.0"},
+        additional_environment={"CHARTREUSE_ENABLE_STOP_PODS": "", "HELM_CHART_APP_VERSION": "5.0.0"},
     )
 
     chartreuse.chartreuse_upgrade.main()
@@ -52,7 +52,7 @@ def test_chartreuse_upgrade_no_migration_disabled_stop_pods(
     mocked_stop_pods = mocker.patch("wiremind_kubernetes.KubernetesDeploymentManager.stop_pods")
     mocker.patch("wiremind_kubernetes.KubernetesDeploymentManager.start_pods")
     mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.0.0")
-    configure_os_environ_mock(mocker=mocker, additional_environment={"HELM_CHART_VERSION": "5.0.0"})
+    configure_os_environ_mock(mocker=mocker, additional_environment={"HELM_CHART_APP_VERSION": "5.0.0"})
 
     chartreuse.chartreuse_upgrade.main()
     mocked_stop_pods.assert_not_called()
@@ -90,7 +90,7 @@ def test_chartreuse_upgrade_compatibility_check(
     Helm Chart version.
     """
     mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value=package_version)
-    additional_environment = {"HELM_CHART_VERSION": helm_chart_version} if helm_chart_version is not None else {}
+    additional_environment = {"HELM_CHART_APP_VERSION": helm_chart_version} if helm_chart_version is not None else {}
     configure_os_environ_mock(mocker=mocker, additional_environment=additional_environment)
     configure_chartreuse_mock(mocker=mocker, is_migration_needed=False)
 

--- a/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade_extended.py
+++ b/src/chartreuse/tests/unit_tests/test_chartreuse_upgrade_extended.py
@@ -14,7 +14,7 @@ class TestEnsureSafeRun:
     def test_ensure_safe_run_matching_versions(self, mocker: MockerFixture) -> None:
         """Test ensure_safe_run with matching major.minor versions."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.2.1")
-        mocker.patch.dict(os.environ, {"HELM_CHART_VERSION": "5.2.0"})
+        mocker.patch.dict(os.environ, {"HELM_CHART_APP_VERSION": "5.2.0"})
 
         # Should not raise any exception
         ensure_safe_run()
@@ -22,7 +22,7 @@ class TestEnsureSafeRun:
     def test_ensure_safe_run_mismatched_versions(self, mocker: MockerFixture) -> None:
         """Test ensure_safe_run with mismatched major.minor versions."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.1.3")
-        mocker.patch.dict(os.environ, {"HELM_CHART_VERSION": "5.2.0"})
+        mocker.patch.dict(os.environ, {"HELM_CHART_APP_VERSION": "5.2.0"})
 
         with pytest.raises(ValueError) as exc_info:
             ensure_safe_run()
@@ -32,29 +32,29 @@ class TestEnsureSafeRun:
         assert "5.2.0" in str(exc_info.value)
 
     def test_ensure_safe_run_missing_helm_version(self, mocker: MockerFixture) -> None:
-        """Test ensure_safe_run with missing HELM_CHART_VERSION environment variable."""
+        """Test ensure_safe_run with missing HELM_CHART_APP_VERSION environment variable."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.1.3")
         mocker.patch.dict(os.environ, {}, clear=True)
 
         with pytest.raises(ValueError) as exc_info:
             ensure_safe_run()
 
-        assert "Couldn't get the Chartreuse's Helm Chart version" in str(exc_info.value)
+        assert "Couldn't get the Chartreuse's Helm Chart appVersion" in str(exc_info.value)
 
     def test_ensure_safe_run_empty_helm_version(self, mocker: MockerFixture) -> None:
-        """Test ensure_safe_run with empty HELM_CHART_VERSION environment variable."""
+        """Test ensure_safe_run with empty HELM_CHART_APP_VERSION environment variable."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.1.3")
-        mocker.patch.dict(os.environ, {"HELM_CHART_VERSION": ""})
+        mocker.patch.dict(os.environ, {"HELM_CHART_APP_VERSION": ""})
 
         with pytest.raises(ValueError) as exc_info:
             ensure_safe_run()
 
-        assert "Couldn't get the Chartreuse's Helm Chart version" in str(exc_info.value)
+        assert "Couldn't get the Chartreuse's Helm Chart appVersion" in str(exc_info.value)
 
     def test_ensure_safe_run_different_major_versions(self, mocker: MockerFixture) -> None:
         """Test ensure_safe_run with different major versions."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="4.2.1")
-        mocker.patch.dict(os.environ, {"HELM_CHART_VERSION": "5.2.0"})
+        mocker.patch.dict(os.environ, {"HELM_CHART_APP_VERSION": "5.2.0"})
 
         with pytest.raises(ValueError) as exc_info:
             ensure_safe_run()
@@ -64,7 +64,7 @@ class TestEnsureSafeRun:
     def test_ensure_safe_run_complex_version_formats(self, mocker: MockerFixture) -> None:
         """Test ensure_safe_run with complex version formats."""
         mocker.patch("chartreuse.chartreuse_upgrade.get_version", return_value="5.2.1-alpha.1")
-        mocker.patch.dict(os.environ, {"HELM_CHART_VERSION": "5.2.0-beta.2"})
+        mocker.patch.dict(os.environ, {"HELM_CHART_APP_VERSION": "5.2.0-beta.2"})
 
         # Should not raise any exception as major.minor match
         ensure_safe_run()


### PR DESCRIPTION
…VERSION

The env var now carries the Helm chart's appVersion (the chartreuse application/package version) rather than the chart's own version, since ensure_safe_run() checks package/chart compatibility against appVersion. Rename the key and error message accordingly, and update tests.

Requires the matching rename in the wiremind-helm-charts confimap.yaml (.Chart.appVersion); the two must ship together.